### PR TITLE
Feat: 관광지 관련 Entity 생성

### DIFF
--- a/src/main/java/com/ssafy/trip/attraction/domain/Attraction.java
+++ b/src/main/java/com/ssafy/trip/attraction/domain/Attraction.java
@@ -1,0 +1,73 @@
+package com.ssafy.trip.attraction.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "attractions")
+public class Attraction {
+    @Id
+    private Integer no;
+
+    private Integer contentId;
+
+    @NotNull
+    @Column(length = 500)
+    private String title;
+
+    @NotNull
+    @Column(length = 100)
+    private String firstImage1;
+
+    @Column(length = 100)
+    private String firstImage2;
+
+    @NotNull
+    private Integer mapLevel;
+
+    @NotNull
+    @Column(precision = 20, scale = 17)
+    private BigDecimal latitude;
+
+    @NotNull
+    @Column(precision = 20, scale = 17)
+    private BigDecimal longitude;
+
+    @Column(length = 20)
+    private String tel;
+
+    @NotNull
+    @Column(length = 100)
+    private String addr1;
+
+    @Column(length = 100)
+    private String addr2;
+
+    @Column(length = 1000)
+    private String homepage;
+
+    @Column(length = 10000)
+    private String overview;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "content_type_id")
+    private ContentType contentTypeId;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "area_code", referencedColumnName = "sidoCode")
+    private Sido areaCode;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "si_gun_gu_code", referencedColumnName = "gugunCode")
+    private Gugun siGunGuCode;
+}

--- a/src/main/java/com/ssafy/trip/attraction/domain/ContentType.java
+++ b/src/main/java/com/ssafy/trip/attraction/domain/ContentType.java
@@ -1,0 +1,23 @@
+package com.ssafy.trip.attraction.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "contenttypes")
+public class ContentType {
+    @Id
+    private Integer contentTypeId;
+
+    @NotNull
+    @Column(length = 10)
+    private String contentTypeName;
+}

--- a/src/main/java/com/ssafy/trip/attraction/domain/Gugun.java
+++ b/src/main/java/com/ssafy/trip/attraction/domain/Gugun.java
@@ -1,0 +1,34 @@
+package com.ssafy.trip.attraction.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "guguns", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "guguns_sido_to_sidos_cdoe_fk",
+                columnNames = "gugun_code"
+        )
+})
+
+public class Gugun {
+    @Id
+    private Integer no;
+
+    @NotNull
+    private Integer gugunCode;
+
+    @NotNull
+    @Column(length = 20)
+    private String gugunName;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "sido_code")
+    private Sido sidoCode;
+}

--- a/src/main/java/com/ssafy/trip/attraction/domain/Sido.java
+++ b/src/main/java/com/ssafy/trip/attraction/domain/Sido.java
@@ -1,0 +1,28 @@
+package com.ssafy.trip.attraction.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "sidos", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "sido_code_UNIQUE",
+                columnNames = "sido_code"
+        )
+})
+public class Sido {
+    @Id
+    private Integer no;
+
+    @NotNull
+    private Integer sidoCode;
+
+    @NotNull
+    @Column(length = 20)
+    private String sidoName;
+}


### PR DESCRIPTION
### ✏️ 완료한 기능 명세

- [x] `content_type` entity 생성
- [X] `sido` entity 생성
- [X] `gugun` entity 생성
- [X] `attraction` entity 생성


### 📷 결과물 이미지

validation error 없이 실행되는 모습을 볼 수 있습니다.

![image](https://github.com/user-attachments/assets/47868f67-950a-44f3-bcf8-e998fbe49f27)


### 🤔 고민한 부분

- entity들의 생성 위치를 고민했는데, 모두 Attraction을 위해 있는 테이블이고 따로 `content_type`, `sido`, `gugun`만을 조회하는 API가 없어서 `attraction.domain`에 같이 만들었습니다.
- 위도, 경도 컬럼을 생성할 때 `BigDecimal` 타입을 사용했습니다.
- 각 테이블 간의 1:N 관계, unique contraint 설정 등 spring boot의 방식을 찾아보며 적용했습니다.

### 참고 자료

- https://kingjakeu.github.io/java/2020/12/23/bigdecimal/
- https://steady-hello.tistory.com/103
- https://ttl-blog.tistory.com/1176