### PR TITLE
Feat: Article Entity 생성 및 CSRF 보호 비활성화

### DIFF
--- a/src/main/java/com/ssafy/trip/article/domain/Article.java
+++ b/src/main/java/com/ssafy/trip/article/domain/Article.java
@@ -1,0 +1,37 @@
+package com.ssafy.trip.article.domain;
+
+import com.ssafy.trip.attraction.domain.Attraction;
+import com.ssafy.trip.common.jpa.BaseTimeEntity;
+import com.ssafy.trip.member.domain.Member;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "articles")
+public class Article extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 500)
+    private String content;
+
+    private LocalDateTime deletedAt;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "member_id", referencedColumnName = "id")
+    private Member member;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "attraction_id", referencedColumnName = "no")
+    private Attraction attraction;
+}

--- a/src/main/java/com/ssafy/trip/article/domain/ArticleImage.java
+++ b/src/main/java/com/ssafy/trip/article/domain/ArticleImage.java
@@ -1,0 +1,25 @@
+package com.ssafy.trip.article.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "article_images")
+public class ArticleImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String imageUrl;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "article_id", referencedColumnName = "id")
+    private Article article;
+}

--- a/src/main/java/com/ssafy/trip/common/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/trip/common/config/SecurityConfig.java
@@ -19,7 +19,9 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // TODO: 프론트 개발 시 CSRF 함께 관리하여 CSRF 보호 활성화하기
         http
+                .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers("/**").permitAll()
                         .anyRequest().authenticated())


### PR DESCRIPTION
### ✏️ 완료한 기능 명세

- [X] Article Entity 생성
- [X] Spring Security CSRF 보호 비활성화


### 🤔 고민한 부분

- Spring Security에서 기본적으로 CSRF 보호를 하는데, 이렇게 되면 프론트에서도 CSFR 토큰을 같이 보내주어야 403 에러가 발생하지 않습니다. 그래서 임시로 비활성화해두었고 나중에 프론트 개발하면 같이 CSRF 토큰 관리하도록 하면 될 것 같습니다.

### 참고 자료

[CSRF 토큰 관련 블로그](https://velog.io/@jhbae0420/%EB%BD%80%EB%AA%A8%EB%8F%84%EB%A1%9C-%EB%A9%94%EC%9D%B4%ED%8A%B8-%EC%8A%A4%ED%94%84%EB%A7%81-%EC%8B%9C%ED%81%90%EB%A6%AC%ED%8B%B0%EC%9D%98-CSRF-%ED%95%84%ED%84%B0-%ED%95%B4%EC%A0%9C%EB%A5%BC-%ED%86%B5%ED%95%9C-403-Forbidden-%EC%97%90%EB%9F%AC-%ED%95%B4%EA%B2%B0)