### PR TITLE
Refactor: RuntimeException으로 수정, JPA 쿼리메서드 변경

### DIFF
--- a/src/main/java/com/ssafy/trip/areacharacter/controller/AreaCharacterController.java
+++ b/src/main/java/com/ssafy/trip/areacharacter/controller/AreaCharacterController.java
@@ -57,9 +57,9 @@ public class AreaCharacterController {
             @PathVariable Integer attractionId, @RequestPart MultipartFile imageFile, HttpSession session
     ) {
         Map<String, Object> userInfo = (HashMap<String, Object>) session.getAttribute("userInfo");
-        Long id = (Long) userInfo.get("id");
+        Long memberId = (Long) userInfo.get("id");
         try {
-            AreaCharacter areaCharacter = areaCharacterService.createCharacterOfMember(imageFile, attractionId, id);
+            AreaCharacter areaCharacter = areaCharacterService.createCharacterOfMember(imageFile, attractionId, memberId);
             CreatedCharacterResponse characterResponse = CreatedCharacterResponse.builder()
                     .areaCharacter(areaCharacter)
                     .build();

--- a/src/main/java/com/ssafy/trip/areacharacter/service/AreaCharacterService.java
+++ b/src/main/java/com/ssafy/trip/areacharacter/service/AreaCharacterService.java
@@ -14,7 +14,7 @@ import java.util.List;
 public interface AreaCharacterService {
     List<MemberCharacter> findCharactersByMemberId(Long memberId);
 
-    AreaCharacter createCharacterOfMember(MultipartFile imageFile, Integer attractionId) throws IOException, ImageProcessingException, NotCertifiedException;
+    AreaCharacter createCharacterOfMember(MultipartFile imageFile, Integer attractionId, Long id) throws IOException, ImageProcessingException, NotCertifiedException;
 
     GeoLocation getGeoLocation(MultipartFile imageFile) throws IOException, ImageProcessingException, NotCertifiedException;
 

--- a/src/main/java/com/ssafy/trip/areacharacter/service/AreaCharacterServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/areacharacter/service/AreaCharacterServiceImpl.java
@@ -11,6 +11,7 @@ import com.ssafy.trip.areacharacter.domain.AreaCharacter;
 import com.ssafy.trip.areacharacter.domain.MemberCharacter;
 import com.ssafy.trip.areacharacter.repository.AreaCharacterRepository;
 import com.ssafy.trip.areacharacter.repository.MemberCharacterRepository;
+import com.ssafy.trip.common.exception.MemberNotFoundException;
 import com.ssafy.trip.common.exception.NotCertifiedException;
 import com.ssafy.trip.member.domain.Member;
 import com.ssafy.trip.member.repository.MemberRepository;
@@ -44,7 +45,7 @@ public class AreaCharacterServiceImpl implements AreaCharacterService {
     }
 
     @Override
-    public AreaCharacter createCharacterOfMember(MultipartFile imageFile, Integer attractionId)
+    public AreaCharacter createCharacterOfMember(MultipartFile imageFile, Integer attractionId, Long id)
             throws IOException, ImageProcessingException, NotCertifiedException {
         GeoLocation geoLocation = getGeoLocation(imageFile);
         Attraction attraction = attractionRepository.findByNo(attractionId);
@@ -53,8 +54,8 @@ public class AreaCharacterServiceImpl implements AreaCharacterService {
             throw new NotCertifiedException("User Location is not near the attraction");
         }
 
-        // TODO: 소셜로그인 기능 구현되면 사용자 아이디 수정
-        Member member = memberRepository.findById(1);
+        Member member = memberRepository.findByIdAndDeletedAtIsNotNull(id).orElseThrow(() ->
+                new MemberNotFoundException("The user ID " + id + " is invalid or the account no longer exists."));
         AreaCharacter areaCharacter = areaCharacterRepository.findBySidoId(attraction.getAreaCode());
 
         MemberCharacter memberCharacter = memberCharacterRepository.save(MemberCharacter.builder()

--- a/src/main/java/com/ssafy/trip/areacharacter/service/AreaCharacterServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/areacharacter/service/AreaCharacterServiceImpl.java
@@ -45,7 +45,7 @@ public class AreaCharacterServiceImpl implements AreaCharacterService {
     }
 
     @Override
-    public AreaCharacter createCharacterOfMember(MultipartFile imageFile, Integer attractionId, Long id)
+    public AreaCharacter createCharacterOfMember(MultipartFile imageFile, Integer attractionId, Long memberId)
             throws IOException, ImageProcessingException, NotCertifiedException {
         GeoLocation geoLocation = getGeoLocation(imageFile);
         Attraction attraction = attractionRepository.findByNo(attractionId);
@@ -54,8 +54,8 @@ public class AreaCharacterServiceImpl implements AreaCharacterService {
             throw new NotCertifiedException("User Location is not near the attraction");
         }
 
-        Member member = memberRepository.findByIdAndDeletedAtIsNotNull(id).orElseThrow(() ->
-                new MemberNotFoundException("The user ID " + id + " is invalid or the account no longer exists."));
+        Member member = memberRepository.findByIdAndDeletedAtIsNotNull(memberId).orElseThrow(() ->
+                new MemberNotFoundException("The user ID " + memberId + " is invalid or the account no longer exists."));
         AreaCharacter areaCharacter = areaCharacterRepository.findBySidoId(attraction.getAreaCode());
 
         MemberCharacter memberCharacter = memberCharacterRepository.save(MemberCharacter.builder()

--- a/src/main/java/com/ssafy/trip/common/exception/MemberNotFoundException.java
+++ b/src/main/java/com/ssafy/trip/common/exception/MemberNotFoundException.java
@@ -1,5 +1,5 @@
 package com.ssafy.trip.common.exception;
 
-public class MemberNotFoundException extends Exception {
+public class MemberNotFoundException extends RuntimeException {
     public MemberNotFoundException(String message) { super(message); }
 }

--- a/src/main/java/com/ssafy/trip/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/trip/member/controller/MemberController.java
@@ -26,7 +26,7 @@ public class MemberController {
                     .build();
             return ResponseEntity.status(HttpStatus.OK).body(memberResponse);
         } catch (MemberNotFoundException e) {
-            return ResponseEntity.badRequest().body("No such user: " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("No such user: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/com/ssafy/trip/member/repository/MemberRepository.java
+++ b/src/main/java/com/ssafy/trip/member/repository/MemberRepository.java
@@ -4,9 +4,11 @@ import com.ssafy.trip.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsBySocialId(String socialId);
     Member findBySocialId(String socialId);
-    Member findById(long id);
+    Optional<Member> findByIdAndDeletedAtIsNotNull(long id);
 }

--- a/src/main/java/com/ssafy/trip/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/trip/member/service/MemberService.java
@@ -16,11 +16,8 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public Member findById(Long id) throws MemberNotFoundException {
-        Member member = memberRepository.findById(id).orElse(null);
-        if(member == null || member.getDeletedAt() != null) {
-            throw new MemberNotFoundException("The user ID " + id + " is invalid or the account no longer exists.");
-        }
-        return member;
+        return memberRepository.findByIdAndDeletedAtIsNotNull(id).orElseThrow(() ->
+                new MemberNotFoundException("The user ID " + id + " is invalid or the account no longer exists."));
     }
 
 }


### PR DESCRIPTION

### ✏️ 완료한 기능 명세

- [x] MemberNotFoundException를 언체크 예외로 변경
- [x] JPA 쿼리 메서드 findById -> findByIdAndDeletedAtIsNotNull 변경

### 🤔 고민한 부분

- 커스텀 예외를 만들 때 일반적으로 RuntimeException(언체크 예외)를 상속받음
- 멤버가 삭제된 경우도 예외로 처리하기 위해 JPA 쿼리메서드 변경

### 참고 자료
https://mangkyu.tistory.com/152
