### PR TITLE
Feat: 게시물 생성 및 이미지 업로드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	implementation 'org.springframework.security:spring-security-oauth2-client'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
 	implementation 'com.drewnoakes:metadata-extractor:2.18.0'
+	implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.529')
+	implementation 'com.amazonaws:aws-java-sdk-s3'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/ssafy/trip/areacharacter/service/AreaCharacterServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/areacharacter/service/AreaCharacterServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -49,7 +50,9 @@ public class AreaCharacterServiceImpl implements AreaCharacterService {
     @Override
     public AreaCharacter createCharacterOfMember(MultipartFile imageFile, Integer attractionId, Long memberId) {
         GeoLocation geoLocation = getGeoLocation(imageFile);
-        Attraction attraction = attractionRepository.findByNo(attractionId);
+        Attraction attraction = attractionRepository.findByNo(attractionId).orElseThrow(() ->
+                    new BadRequestException(ErrorCode.ATTRACTION_NOT_FOUND)
+                );
 
         if (!isExistNear(geoLocation, attraction)) {
             throw new NotCertifiedException(ErrorCode.FAR_FROM_ATTRACTION);

--- a/src/main/java/com/ssafy/trip/article/controller/ArticleController.java
+++ b/src/main/java/com/ssafy/trip/article/controller/ArticleController.java
@@ -1,0 +1,49 @@
+package com.ssafy.trip.article.controller;
+
+import com.ssafy.trip.article.dto.CreateArticleRequest;
+import com.ssafy.trip.article.dto.CreatedAtricleResponse;
+import com.ssafy.trip.article.service.ArticleService;
+import com.ssafy.trip.common.exception.ErrorCode;
+import com.ssafy.trip.common.exception.custom.BadRequestException;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashMap;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/articles")
+public class ArticleController {
+    private final ArticleService articleService;
+
+    @PostMapping
+    public ResponseEntity<CreatedAtricleResponse> createArticle(
+            @RequestPart List<MultipartFile> images,
+            @RequestPart(value = "articleData") CreateArticleRequest createArticleRequest,
+            HttpSession httpSession) {
+        HashMap<String, Object> userInfo = (HashMap<String, Object>) httpSession.getAttribute("userInfo");
+
+        if (!createArticleRequest.getMemberId().equals(userInfo.get("id"))) {
+            throw new BadRequestException(ErrorCode.MEMBER_NOT_MATCH);
+        }
+
+        Long articleId = articleService.createArticle(
+                createArticleRequest.getContent(),
+                createArticleRequest.getMemberId(),
+                createArticleRequest.getAttractionId(),
+                images
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                CreatedAtricleResponse.builder().id(articleId).build()
+        );
+    }
+}

--- a/src/main/java/com/ssafy/trip/article/domain/Article.java
+++ b/src/main/java/com/ssafy/trip/article/domain/Article.java
@@ -5,14 +5,13 @@ import com.ssafy.trip.common.jpa.BaseTimeEntity;
 import com.ssafy.trip.member.domain.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @ToString
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "articles")
 public class Article extends BaseTimeEntity {
@@ -27,11 +26,18 @@ public class Article extends BaseTimeEntity {
 
     @NotNull
     @ManyToOne
-    @JoinColumn(name = "member_id", referencedColumnName = "id")
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @NotNull
     @ManyToOne
-    @JoinColumn(name = "attraction_id", referencedColumnName = "no")
+    @JoinColumn(name = "attraction_id")
     private Attraction attraction;
+
+    @Builder
+    public Article(String content, Member member, Attraction attraction) {
+        this.content = content;
+        this.member = member;
+        this.attraction = attraction;
+    }
 }

--- a/src/main/java/com/ssafy/trip/article/domain/ArticleImage.java
+++ b/src/main/java/com/ssafy/trip/article/domain/ArticleImage.java
@@ -2,12 +2,11 @@ package com.ssafy.trip.article.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Entity
 @ToString
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "article_images")
 public class ArticleImage {
@@ -22,4 +21,10 @@ public class ArticleImage {
     @ManyToOne
     @JoinColumn(name = "article_id", referencedColumnName = "id")
     private Article article;
+
+    @Builder
+    public ArticleImage(String imageUrl, Article article) {
+        this.imageUrl = imageUrl;
+        this.article = article;
+    }
 }

--- a/src/main/java/com/ssafy/trip/article/dto/CreateArticleRequest.java
+++ b/src/main/java/com/ssafy/trip/article/dto/CreateArticleRequest.java
@@ -1,0 +1,18 @@
+package com.ssafy.trip.article.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class CreateArticleRequest {
+    @NotNull
+    private String content;
+
+    @NotNull
+    private Long memberId;
+
+    @NotNull
+    private Integer attractionId;
+}

--- a/src/main/java/com/ssafy/trip/article/dto/CreatedAtricleResponse.java
+++ b/src/main/java/com/ssafy/trip/article/dto/CreatedAtricleResponse.java
@@ -1,0 +1,12 @@
+package com.ssafy.trip.article.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class CreatedAtricleResponse {
+    private Long id;
+}

--- a/src/main/java/com/ssafy/trip/article/repository/ArticleImageRepository.java
+++ b/src/main/java/com/ssafy/trip/article/repository/ArticleImageRepository.java
@@ -1,0 +1,7 @@
+package com.ssafy.trip.article.repository;
+
+import com.ssafy.trip.article.domain.ArticleImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleImageRepository extends JpaRepository<ArticleImage, Long> {
+}

--- a/src/main/java/com/ssafy/trip/article/repository/ArticleRepository.java
+++ b/src/main/java/com/ssafy/trip/article/repository/ArticleRepository.java
@@ -1,0 +1,7 @@
+package com.ssafy.trip.article.repository;
+
+import com.ssafy.trip.article.domain.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+}

--- a/src/main/java/com/ssafy/trip/article/service/ArticleService.java
+++ b/src/main/java/com/ssafy/trip/article/service/ArticleService.java
@@ -3,9 +3,11 @@ package com.ssafy.trip.article.service;
 import com.ssafy.trip.member.domain.Member;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
 import java.util.List;
 
 public interface ArticleService {
     Long createArticle(String content, Long memberId, Integer attractionId, List<MultipartFile> images);
-    List<String> uploadImage(Member member, List<MultipartFile> images);
+    String uploadImage(Member member, MultipartFile imageFile);
+    String uploadImage(Member member, File imageFile);
 }

--- a/src/main/java/com/ssafy/trip/article/service/ArticleService.java
+++ b/src/main/java/com/ssafy/trip/article/service/ArticleService.java
@@ -1,0 +1,11 @@
+package com.ssafy.trip.article.service;
+
+import com.ssafy.trip.member.domain.Member;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface ArticleService {
+    Long createArticle(String content, Long memberId, Integer attractionId, List<MultipartFile> images);
+    List<String> uploadImage(Member member, List<MultipartFile> images);
+}

--- a/src/main/java/com/ssafy/trip/article/service/ArticleService.java
+++ b/src/main/java/com/ssafy/trip/article/service/ArticleService.java
@@ -5,9 +5,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.util.List;
+import java.util.Optional;
 
 public interface ArticleService {
     Long createArticle(String content, Long memberId, Integer attractionId, List<MultipartFile> images);
-    String uploadImage(Member member, MultipartFile imageFile);
-    String uploadImage(Member member, File imageFile);
 }

--- a/src/main/java/com/ssafy/trip/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/article/service/ArticleServiceImpl.java
@@ -1,0 +1,75 @@
+package com.ssafy.trip.article.service;
+
+import com.ssafy.trip.article.domain.Article;
+import com.ssafy.trip.article.domain.ArticleImage;
+import com.ssafy.trip.article.repository.ArticleImageRepository;
+import com.ssafy.trip.article.repository.ArticleRepository;
+import com.ssafy.trip.attraction.domain.Attraction;
+import com.ssafy.trip.attraction.repository.AttractionRepository;
+import com.ssafy.trip.common.exception.ErrorCode;
+import com.ssafy.trip.common.exception.custom.NotFoundException;
+import com.ssafy.trip.member.domain.Member;
+import com.ssafy.trip.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ArticleServiceImpl implements ArticleService {
+    private final ArticleRepository articleRepository;
+    private final ArticleImageRepository articleImageRepository;
+    private final MemberRepository memberRepository;
+    private final AttractionRepository attractionRepository;
+
+    @Override
+    public Long createArticle(String content, Long memberId, Integer attractionId, List<MultipartFile> images) {
+        Member member = memberRepository.findById(memberId).orElse(null);
+        Attraction attraction = attractionRepository.findById(attractionId).orElse(null);
+
+        if (member == null) {
+            throw new NotFoundException(ErrorCode.MEMBER_NOT_FOUND);
+        } else if (attraction == null) {
+            throw new NotFoundException(ErrorCode.ATTRACTION_NOT_FOUND);
+        }
+
+        Article article = articleRepository.save(
+                Article.builder()
+                        .content(content)
+                        .member(member)
+                        .attraction(attraction)
+                        .build()
+        );
+
+        List<String> urlList = uploadImage(member, images);
+        List<ArticleImage> articleImageList = new ArrayList<>();
+
+        for (String url : urlList) {
+            articleImageList.add(
+                    ArticleImage.builder()
+                            .article(article)
+                            .imageUrl(url)
+                            .build());
+        }
+
+        articleImageRepository.saveAll(articleImageList);
+
+        return article.getId();
+    }
+
+    @Override
+    public List<String> uploadImage(Member member, List<MultipartFile> images) {
+        List<String> urlList = new ArrayList<>();
+
+        // Object storage
+
+        return urlList;
+    }
+
+
+}

--- a/src/main/java/com/ssafy/trip/attraction/repository/AttractionRepository.java
+++ b/src/main/java/com/ssafy/trip/attraction/repository/AttractionRepository.java
@@ -3,6 +3,8 @@ package com.ssafy.trip.attraction.repository;
 import com.ssafy.trip.attraction.domain.Attraction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AttractionRepository extends JpaRepository<Attraction, Integer> {
-    Attraction findByNo(Integer no);
+    Optional<Attraction> findByNo(Integer no);
 }

--- a/src/main/java/com/ssafy/trip/common/config/S3Config.java
+++ b/src/main/java/com/ssafy/trip/common/config/S3Config.java
@@ -3,6 +3,7 @@ package com.ssafy.trip.common.config;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import lombok.Getter;
@@ -32,8 +33,8 @@ public class S3Config {
 
         return AmazonS3ClientBuilder
                 .standard()
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endPoint, regionName))
                 .withCredentials(new AWSStaticCredentialsProvider(credentials))
-                .withRegion(regionName)
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/trip/common/config/S3Config.java
+++ b/src/main/java/com/ssafy/trip/common/config/S3Config.java
@@ -1,15 +1,39 @@
 package com.ssafy.trip.common.config;
 
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConfigurationProperties(prefix = "aws-sdk")
 @Getter
 public class S3Config {
-    private String endpoint;
-    private String bucketname;
-    private String accesskey;
-    private String secretkey;
+    @Value("${aws-sdk.endPoint}")
+    private String endPoint;
+
+    @Value("${aws-sdk.regionName}")
+    private String regionName;
+
+    @Value("${aws-sdk.accessKey}")
+    private String accessKey;
+
+    @Value("${aws-sdk.secretKey}")
+    private String secretKey;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(regionName)
+                .build();
+    }
 }

--- a/src/main/java/com/ssafy/trip/common/config/S3Config.java
+++ b/src/main/java/com/ssafy/trip/common/config/S3Config.java
@@ -1,0 +1,15 @@
+package com.ssafy.trip.common.config;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "aws-sdk")
+@Getter
+public class S3Config {
+    private String endpoint;
+    private String bucketname;
+    private String accesskey;
+    private String secretkey;
+}

--- a/src/main/java/com/ssafy/trip/common/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/trip/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     IMAGE_READ_ERROR(HttpStatus.BAD_REQUEST, "Failed to read image file"),
     IMAGE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "Failed to upload image file"),
     IMAGE_ORIGINALNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "Image original name is not exist"),
+    IMAGE_CONVERT_ERROR(HttpStatus.BAD_REQUEST, "Failed to convert image file from multipart file"),
 
     FAR_FROM_ATTRACTION(HttpStatus.BAD_REQUEST, "User Location is not near the attraction"),
     GEOLOCATION_IS_NULL(HttpStatus.BAD_REQUEST, "Geo location is null"),

--- a/src/main/java/com/ssafy/trip/common/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/trip/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     IMAGE_PROCESSING_ERROR(HttpStatus.BAD_REQUEST, "Failed to process image metadata"),
     IMAGE_READ_ERROR(HttpStatus.BAD_REQUEST, "Failed to read image file"),
+    IMAGE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "Failed to upload image file"),
 
     FAR_FROM_ATTRACTION(HttpStatus.BAD_REQUEST, "User Location is not near the attraction"),
     GEOLOCATION_IS_NULL(HttpStatus.BAD_REQUEST, "Geo location is null"),

--- a/src/main/java/com/ssafy/trip/common/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/trip/common/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     IMAGE_PROCESSING_ERROR(HttpStatus.BAD_REQUEST, "Failed to process image metadata"),
     IMAGE_READ_ERROR(HttpStatus.BAD_REQUEST, "Failed to read image file"),
     IMAGE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "Failed to upload image file"),
+    IMAGE_ORIGINALNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "Image original name is not exist"),
 
     FAR_FROM_ATTRACTION(HttpStatus.BAD_REQUEST, "User Location is not near the attraction"),
     GEOLOCATION_IS_NULL(HttpStatus.BAD_REQUEST, "Geo location is null"),

--- a/src/main/java/com/ssafy/trip/common/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/trip/common/exception/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
     FAR_FROM_ATTRACTION(HttpStatus.BAD_REQUEST, "User Location is not near the attraction"),
     GEOLOCATION_IS_NULL(HttpStatus.BAD_REQUEST, "Geo location is null"),
 
+    MEMBER_NOT_MATCH(HttpStatus.BAD_REQUEST, "Request member does not match the session info"),
+
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Member is not found"),
     ATTRACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Attraction is not found");
 

--- a/src/main/java/com/ssafy/trip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ssafy/trip/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.ssafy.trip.common.exception;
 import com.ssafy.trip.common.exception.custom.BadRequestException;
 import com.ssafy.trip.common.exception.custom.NotCertifiedException;
 import com.ssafy.trip.common.exception.custom.NotFoundException;
+import com.ssafy.trip.common.exception.custom.S3Exception;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -24,6 +25,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NotCertifiedException.class)
     public ResponseEntity<ErrorResponse> notCertifiedException(NotCertifiedException e) {
+        ErrorResponse response = new ErrorResponse(e.getStatus(), e.getMessage());
+        return ResponseEntity.status(e.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(S3Exception.class)
+    public ResponseEntity<ErrorResponse> s3Exception(S3Exception e) {
         ErrorResponse response = new ErrorResponse(e.getStatus(), e.getMessage());
         return ResponseEntity.status(e.getStatus()).body(response);
     }

--- a/src/main/java/com/ssafy/trip/common/exception/custom/S3Exception.java
+++ b/src/main/java/com/ssafy/trip/common/exception/custom/S3Exception.java
@@ -1,0 +1,16 @@
+package com.ssafy.trip.common.exception.custom;
+
+import com.ssafy.trip.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class S3Exception extends RuntimeException {
+    private final HttpStatus status;
+    private final String message;
+
+    public S3Exception(ErrorCode errorCode) {
+        this.status = errorCode.getStatus();
+        this.message = errorCode.getMessage();
+    }
+}


### PR DESCRIPTION
### ✏️ 완료한 기능 명세

- [x] aws-sdk 라이브러리 설치 및 config 설정
- [x] 게시물 생성 기능 구현
- [x] Object Storage에 이미지 업로드 기능 구현


### 📷 결과물 이미지

![image](https://github.com/user-attachments/assets/94e75b94-56cb-4b29-a026-f2002a965832)

![image](https://github.com/user-attachments/assets/37bfbfc1-0d81-444e-8ba2-48315cb24b42)


### 🤔 고민한 부분

- Object Storage에 이미지를 업로드하는 부분을 이해하는데 시간이 좀 걸렸습니다.
  `MultipartFile`을 받아서 바로 업로드하는 것이 아니라 서버에 저장하여 `File`로 변환 후 이를 업로드해야합니다. 업로드 완료 후 서버에 저장된 파일은 삭제하도록 했고, 파일은 사용자 닉네임 디렉토리에 저장되도록 하였습니다.

### 참고 자료

- https://velog.io/@mingsound21/SpringBoot-AWS-S3%EB%A1%9C-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%97%85%EB%A1%9C%EB%93%9C
- https://guide.ncloud-docs.com/docs/ko/storage-storage-6-1