### PR TITLE
Feat: 좋아요, 좋아요 취소 기능 추가

### DIFF
--- a/src/main/java/com/ssafy/trip/article/controller/ArticleController.java
+++ b/src/main/java/com/ssafy/trip/article/controller/ArticleController.java
@@ -1,9 +1,6 @@
 package com.ssafy.trip.article.controller;
 
-import com.ssafy.trip.article.dto.ArticleListResponse;
-import com.ssafy.trip.article.dto.ArticleResponse;
-import com.ssafy.trip.article.dto.CreateArticleRequest;
-import com.ssafy.trip.article.dto.CreatedAtricleResponse;
+import com.ssafy.trip.article.dto.*;
 import com.ssafy.trip.article.service.ArticleService;
 import com.ssafy.trip.common.exception.ErrorCode;
 import com.ssafy.trip.common.exception.custom.BadRequestException;
@@ -60,4 +57,25 @@ public class ArticleController {
 
         return ResponseEntity.ok(responseDto.getArticles());
     }
+
+    @PostMapping("/{articleId}/likes")
+    public ResponseEntity<LikeResponse> addLike(HttpSession httpSession, @PathVariable Long articleId) {
+        HashMap<String, Object> userInfo = (HashMap<String, Object>) httpSession.getAttribute("userInfo");
+        Long memberId = (Long) userInfo.get("id");
+        LikeResponse likeResponse = LikeResponse.builder()
+                .likeCount(articleService.addLike(memberId, articleId)).build();
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(likeResponse);
+    }
+
+    @DeleteMapping("{articleId}/likes")
+    public ResponseEntity<LikeResponse> deleteLike(HttpSession httpSession, @PathVariable Long articleId) {
+        HashMap<String, Object> userInfo = (HashMap<String, Object>) httpSession.getAttribute("userInfo");
+        Long memberId = (Long) userInfo.get("id");
+        LikeResponse likeResponse = LikeResponse.builder()
+                .likeCount(articleService.removeLike(memberId, articleId)).build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(likeResponse);
+    }
+
 }

--- a/src/main/java/com/ssafy/trip/article/domain/Like.java
+++ b/src/main/java/com/ssafy/trip/article/domain/Like.java
@@ -3,16 +3,16 @@ package com.ssafy.trip.article.domain;
 import com.ssafy.trip.member.domain.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Entity
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "likes")
+@Table(name = "likes",
+        uniqueConstraints = @UniqueConstraint(
+                columnNames = {"member_id", "article_id"}
+        ))
 public class Like {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,4 +27,10 @@ public class Like {
     @ManyToOne
     @JoinColumn(name = "article_id")
     private Article article;
+
+    @Builder
+    public Like(Member member, Article article) {
+        this.member = member;
+        this.article = article;
+    }
 }

--- a/src/main/java/com/ssafy/trip/article/dto/LikeResponse.java
+++ b/src/main/java/com/ssafy/trip/article/dto/LikeResponse.java
@@ -1,0 +1,12 @@
+package com.ssafy.trip.article.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class LikeResponse {
+    private Long likeCount;
+}

--- a/src/main/java/com/ssafy/trip/article/repository/LikeRepository.java
+++ b/src/main/java/com/ssafy/trip/article/repository/LikeRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
     Optional<Like> findByMemberAndArticle(Member member, Article article);
+    Boolean existsByMemberAndArticle(Member member, Article article);
     Long countByArticle(Article article);
 }

--- a/src/main/java/com/ssafy/trip/article/repository/LikeRepository.java
+++ b/src/main/java/com/ssafy/trip/article/repository/LikeRepository.java
@@ -1,0 +1,13 @@
+package com.ssafy.trip.article.repository;
+
+import com.ssafy.trip.article.domain.Article;
+import com.ssafy.trip.article.domain.Like;
+import com.ssafy.trip.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    Optional<Like> findByMemberAndArticle(Member member, Article article);
+    Long countByArticle(Article article);
+}

--- a/src/main/java/com/ssafy/trip/article/service/ArticleService.java
+++ b/src/main/java/com/ssafy/trip/article/service/ArticleService.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface ArticleService {
     Long createArticle(String content, Long memberId, Integer attractionId, List<MultipartFile> images);
     List<ArticleResponse> getRecommendedArticles(Integer pageNumber);
+    Long addLike(Long articleId, Long memberId);
+    Long removeLike(Long articleId, Long memberId);
 }

--- a/src/main/java/com/ssafy/trip/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/article/service/ArticleServiceImpl.java
@@ -120,6 +120,10 @@ public class ArticleServiceImpl implements ArticleService {
                 new BadRequestException(ErrorCode.MEMBER_NOT_FOUND)
         );
 
+        if (likeRepository.existsByMemberAndArticle(member, article)) {
+            throw new BadRequestException(ErrorCode.INVALID_LIKE_ACTION);
+        }
+
         likeRepository.save(Like.builder()
                 .article(article)
                 .member(member)

--- a/src/main/java/com/ssafy/trip/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/article/service/ArticleServiceImpl.java
@@ -5,9 +5,11 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.ssafy.trip.article.domain.Article;
 import com.ssafy.trip.article.domain.ArticleImage;
+import com.ssafy.trip.article.domain.Like;
 import com.ssafy.trip.article.dto.ArticleResponse;
 import com.ssafy.trip.article.repository.ArticleImageRepository;
 import com.ssafy.trip.article.repository.ArticleRepository;
+import com.ssafy.trip.article.repository.LikeRepository;
 import com.ssafy.trip.article.util.Pagination;
 import com.ssafy.trip.attraction.domain.Attraction;
 import com.ssafy.trip.attraction.repository.AttractionRepository;
@@ -27,6 +29,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -37,6 +40,7 @@ public class ArticleServiceImpl implements ArticleService {
     private final ArticleImageRepository articleImageRepository;
     private final MemberRepository memberRepository;
     private final AttractionRepository attractionRepository;
+    private final LikeRepository likeRepository;
 
     private final AmazonS3 s3Client;
 
@@ -105,6 +109,39 @@ public class ArticleServiceImpl implements ArticleService {
                             .build();
                 })
                 .toList();
+    }
+
+    @Override
+    public Long addLike(Long articleId, Long memberId) {
+        Article article = articleRepository.findById(articleId).orElseThrow(() ->
+                new BadRequestException(ErrorCode.ARTICLE_NOT_FOUND)
+        );
+        Member member = memberRepository.findById(memberId).orElseThrow(() ->
+                new BadRequestException(ErrorCode.MEMBER_NOT_FOUND)
+        );
+
+        likeRepository.save(Like.builder()
+                .article(article)
+                .member(member)
+                .build());
+
+        return likeRepository.countByArticle(article);
+    }
+
+    @Override
+    public Long removeLike(Long articleId, Long memberId) {
+        Article article = articleRepository.findById(articleId).orElseThrow(() ->
+                new BadRequestException(ErrorCode.ARTICLE_NOT_FOUND)
+        );
+        Member member = memberRepository.findById(memberId).orElseThrow(() ->
+                new BadRequestException(ErrorCode.MEMBER_NOT_FOUND)
+        );
+
+        Like like = likeRepository.findByMemberAndArticle(member, article).orElseThrow(() ->
+                new BadRequestException(ErrorCode.INVALID_LIKE_ACTION));
+        likeRepository.delete(like);
+
+        return likeRepository.countByArticle(article);
     }
 
 

--- a/src/main/java/com/ssafy/trip/common/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/trip/common/exception/ErrorCode.java
@@ -18,8 +18,12 @@ public enum ErrorCode {
 
     MEMBER_NOT_MATCH(HttpStatus.BAD_REQUEST, "Request member does not match the session info"),
 
+    INVALID_LIKE_ACTION(HttpStatus.BAD_REQUEST, "Like action is invalid"),
+
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Member is not found"),
-    ATTRACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Attraction is not found");
+    ATTRACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Attraction is not found"),
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND,  "Article is not found");
+
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION

### ✏️ 완료한 기능 명세

- [x] 좋아요 유니크 제약조건 추가
- [x] 좋아요 기능 추가
- [x] 좋아요 취소 기능 추가

### 📷 결과물 이미지

- 변경 전
<img width="741" alt="image" src="https://github.com/user-attachments/assets/00877b15-b997-4de7-9bc5-affa7dfe6e88">

- 변경 후
<img width="742" alt="image" src="https://github.com/user-attachments/assets/92f488a2-6b28-4b9d-8347-b8c7eb39f53a">

- 좋아요
![image](https://github.com/user-attachments/assets/7275b07f-df80-442b-9be2-7a78e26702eb)

- 좋아요 취소
![image](https://github.com/user-attachments/assets/ff38160e-86fc-4851-96f4-1776c819888c)

- 좋아요 상태에서 좋아요 요청
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/d9e9992b-74b7-4f14-a996-97452d6b3bae">

- 좋아요 없는 상태에서 취소 요청
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/7667a1ba-9b49-4ecc-8d6f-3a1184e7a215">


### 🤔 고민한 부분

- 좋아요 기능의 작동방식에 대해 고민해보고 memberId와 articleId로 유니크 제약조건을 추가했습니다.
- 서비스에서 메서드를 하나만 작성해 토글 방식으로 구현할지 따로 구현할지 고민을 해봤고 하나의 메서드에 부여된 역할을 나누는 편이 좋다고 생각해 각각 구현하였습니다.
- 이미 좋아요가 존재하는데 좋아요 생성 요청, 좋아요 없는 상태에서 좋아요 삭제 요청하는 경우에 대한 에러코드를 추가해주었습니다.
