### PR TITLE
Feat: 멤버 캐릭터 별 게시글 조회 API 구현

### DIFF
--- a/src/main/java/com/ssafy/trip/article/controller/ArticleController.java
+++ b/src/main/java/com/ssafy/trip/article/controller/ArticleController.java
@@ -27,10 +27,10 @@ public class ArticleController {
     private static final long MAX_CURSOR_ID = Long.MAX_VALUE;
     private static final String MAX_CURSOR_ID_STR = "" + MAX_CURSOR_ID;
 
-    @GetMapping("/members/{memberId}/sidos/{sidoCode}")
+    @GetMapping("/members/{memberId}/sidos/{sidoId}")
     public ResponseEntity<ArticleListWithLastIdResponse> getMemberCharacterArticle(
             @PathVariable Long memberId,
-            @PathVariable Integer sidoCode,
+            @PathVariable Integer sidoId,
             @RequestParam(defaultValue = MAX_CURSOR_ID_STR) @Min(MAX_CURSOR_ID) Long cursorId,
             HttpSession httpSession
     ) {
@@ -40,7 +40,7 @@ public class ArticleController {
             throw new BadRequestException(ErrorCode.MEMBER_NOT_MATCH);
         }
 
-        List<ArticleResponse> articles = articleService.getArticlesOfMemberCharacter(memberId, sidoCode, cursorId);
+        List<ArticleResponse> articles = articleService.getArticlesOfMemberCharacter(memberId, sidoId, cursorId);
 
         ArticleListWithLastIdResponse responseDto = ArticleListWithLastIdResponse.builder()
                 .articles(articles)

--- a/src/main/java/com/ssafy/trip/article/dto/ArticleListWithLastIdResponse.java
+++ b/src/main/java/com/ssafy/trip/article/dto/ArticleListWithLastIdResponse.java
@@ -1,0 +1,13 @@
+package com.ssafy.trip.article.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ArticleListWithLastIdResponse {
+    private List<ArticleResponse> articles;
+    private Long lastId;
+}

--- a/src/main/java/com/ssafy/trip/article/dto/ArticleResponse.java
+++ b/src/main/java/com/ssafy/trip/article/dto/ArticleResponse.java
@@ -13,7 +13,7 @@ public class ArticleResponse {
     private String content;
     private LocalDateTime createdAt;
     private List<String> imageUrls;
-    private Integer likes;
+    private Long likes;
     private Long memberId;
     private String memberNickname;
 }

--- a/src/main/java/com/ssafy/trip/article/repository/ArticleRepository.java
+++ b/src/main/java/com/ssafy/trip/article/repository/ArticleRepository.java
@@ -18,4 +18,27 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             "ORDER BY likes DESC " +
             "LIMIT :pageSize OFFSET :offset")
     List<Tuple> findRecommendArticles(@Param("pageSize") int pageSize, @Param("offset") int offset);
+
+    @Query("SELECT a.id articleId, " +
+            "a.content articleContent, " +
+            "a.createdAt articleCreatedAt, " +
+            "(SELECT COUNT(l) FROM Like l WHERE l.article = a) likes, " +
+            "m.id memberId, " +
+            "m.nickname memberNickname " +
+            "FROM Article a " +
+            "JOIN a.member m " +
+            "JOIN a.attraction att " +
+            "JOIN att.gugun g " +
+            "WHERE a.id < :cursorId " +
+            "AND m.id = :memberId " +
+            "AND g.sidoCode = :sidoCode " +
+            "AND a.deletedAt IS NULL " +
+            "ORDER BY a.id DESC " +
+            "LIMIT :pageSize")
+    List<Tuple> findArticlesByMemberAndSido(
+            @Param("memberId") Long memberId,
+            @Param("sidoCode") Integer sidoCode,
+            @Param("cursorId") Long cursorId,
+            @Param("pageSize") int pageSize
+    );
 }

--- a/src/main/java/com/ssafy/trip/article/repository/ArticleRepository.java
+++ b/src/main/java/com/ssafy/trip/article/repository/ArticleRepository.java
@@ -29,15 +29,16 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             "JOIN a.member m " +
             "JOIN a.attraction att " +
             "JOIN att.gugun g " +
+            "JOIN g.sido s " +
             "WHERE a.id < :cursorId " +
             "AND m.id = :memberId " +
-            "AND g.sidoCode = :sidoCode " +
+            "AND s.no = :sidoId " +
             "AND a.deletedAt IS NULL " +
             "ORDER BY a.id DESC " +
             "LIMIT :pageSize")
     List<Tuple> findArticlesByMemberAndSido(
             @Param("memberId") Long memberId,
-            @Param("sidoCode") Integer sidoCode,
+            @Param("sidoId") Integer sidoId,
             @Param("cursorId") Long cursorId,
             @Param("pageSize") int pageSize
     );

--- a/src/main/java/com/ssafy/trip/article/service/ArticleService.java
+++ b/src/main/java/com/ssafy/trip/article/service/ArticleService.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface ArticleService {
     Long createArticle(String content, Long memberId, Integer attractionId, List<MultipartFile> images);
     List<ArticleResponse> getRecommendedArticles(Integer pageNumber);
-    List<ArticleResponse> getArticlesOfMemberCharacter(Long memberId, Integer sidoCode, Long cursorId);
+    List<ArticleResponse> getArticlesOfMemberCharacter(Long memberId, Integer sidoId, Long cursorId);
 }

--- a/src/main/java/com/ssafy/trip/article/service/ArticleService.java
+++ b/src/main/java/com/ssafy/trip/article/service/ArticleService.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface ArticleService {
     Long createArticle(String content, Long memberId, Integer attractionId, List<MultipartFile> images);
     List<ArticleResponse> getRecommendedArticles(Integer pageNumber);
+    List<ArticleResponse> getArticlesOfMemberCharacter(Long memberId, Integer sidoCode, Long cursorId);
 }

--- a/src/main/java/com/ssafy/trip/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/article/service/ArticleServiceImpl.java
@@ -109,8 +109,8 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
     @Override
-    public List<ArticleResponse> getArticlesOfMemberCharacter(Long memberId, Integer sidoCode, Long cursorId) {
-        List<Tuple> articles = articleRepository.findArticlesByMemberAndSido(memberId, sidoCode, cursorId, Pagination.PAGE_SIZE.getValue());
+    public List<ArticleResponse> getArticlesOfMemberCharacter(Long memberId, Integer sidoId, Long cursorId) {
+        List<Tuple> articles = articleRepository.findArticlesByMemberAndSido(memberId, sidoId, cursorId, Pagination.PAGE_SIZE.getValue());
 
         return articles.stream()
                 .map(tuple -> {


### PR DESCRIPTION
### ✏️ 완료한 기능 명세

- [x] 멤버 캐릭터 별 게시글 조회 구현


### 📷 결과물 이미지

![image](https://github.com/user-attachments/assets/8cc2fef2-c092-4096-aa80-97519e53048e)


### 🤔 고민한 부분

- 쿼리를 작성할 때 리소스를 절약하기 위해 필요한 컬럼만 조회하도록 했습니다. 다른 곳도 이런 식으로 쿼리를 작성하면 좋을 것 같습니다.
- 처음에 API명세를 작성할 때 캐릭터 아이디를 넘기기로 했는데, 그렇게 하면 조인이 많이 발생되었습니다.
  어차피 프론트에서 캐릭터의 정보를 들고 있기 때문에 요청 시 해당 정보 중 `sido_id`를 반환하면 JOIN을 한 번 줄일 수 있어 명세를 수정했습니다.
