### PR TITLE
Feat: 관광지 관련 게시물 조회 API 구현

### DIFF
--- a/src/main/java/com/ssafy/trip/article/controller/ArticleController.java
+++ b/src/main/java/com/ssafy/trip/article/controller/ArticleController.java
@@ -50,6 +50,21 @@ public class ArticleController {
         return ResponseEntity.ok(responseDto);
     }
 
+    @GetMapping("/attractions/{attractionId}")
+    public ResponseEntity<ArticleListWithLastIdResponse> getAttractionArticle(
+            @PathVariable Integer attractionId,
+            @RequestParam(defaultValue = MAX_CURSOR_ID_STR) @Min(MAX_CURSOR_ID) Long cursorId
+    ) {
+        List<ArticleResponse> articles = articleService.getAtriclesOfAttraction(attractionId, cursorId);
+
+        ArticleListWithLastIdResponse responseDto = ArticleListWithLastIdResponse.builder()
+                .articles(articles)
+                .lastId(articles.get(articles.size() - 1).getId())
+                .build();
+
+        return ResponseEntity.ok(responseDto);
+    }
+
     @PostMapping
     public ResponseEntity<CreatedAtricleResponse> createArticle(
             @RequestPart List<MultipartFile> images,

--- a/src/main/java/com/ssafy/trip/article/repository/ArticleRepository.java
+++ b/src/main/java/com/ssafy/trip/article/repository/ArticleRepository.java
@@ -42,4 +42,24 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             @Param("cursorId") Long cursorId,
             @Param("pageSize") int pageSize
     );
+
+    @Query("SELECT a.id articleId, " +
+            "a.content articleContent, " +
+            "a.createdAt articleCreatedAt, " +
+            "(SELECT COUNT(l) FROM Like l WHERE l.article = a) likes, " +
+            "m.id memberId, " +
+            "m.nickname memberNickname " +
+            "FROM Article a " +
+            "JOIN a.member m " +
+            "JOIN a.attraction att " +
+            "WHERE a.id < :cursorId " +
+            "AND att.no = :attractionId " +
+            "AND a.deletedAt IS NULL " +
+            "ORDER BY a.id DESC " +
+            "LIMIT :pageSize")
+    List<Tuple> findArticlesByAttraction(
+            @Param("attractionId") Integer attractionId,
+            @Param("cursorId") Long cursorId,
+            @Param("pageSize") int pageSize
+    );
 }

--- a/src/main/java/com/ssafy/trip/article/service/ArticleService.java
+++ b/src/main/java/com/ssafy/trip/article/service/ArticleService.java
@@ -9,6 +9,7 @@ public interface ArticleService {
     Long createArticle(String content, Long memberId, Integer attractionId, List<MultipartFile> images);
     List<ArticleResponse> getRecommendedArticles(Integer pageNumber);
     List<ArticleResponse> getArticlesOfMemberCharacter(Long memberId, Integer sidoId, Long cursorId);
+    List<ArticleResponse> getAtriclesOfAttraction(Integer attractionId, Long cursorId);
     Long addLike(Long articleId, Long memberId);
     Long removeLike(Long articleId, Long memberId);
 }

--- a/src/main/java/com/ssafy/trip/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/article/service/ArticleServiceImpl.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -114,24 +113,20 @@ public class ArticleServiceImpl implements ArticleService {
 
     @Override
     public List<ArticleResponse> getArticlesOfMemberCharacter(Long memberId, Integer sidoId, Long cursorId) {
-        List<Tuple> articles = articleRepository.findArticlesByMemberAndSido(memberId, sidoId, cursorId, Pagination.PAGE_SIZE.getValue());
+        List<Tuple> articles = articleRepository.findArticlesByMemberAndSido(
+                memberId, sidoId, cursorId, Pagination.PAGE_SIZE.getValue()
+        );
 
-        return articles.stream()
-                .map(tuple -> {
-                    Long articleId = tuple.get("articleId", Long.class);
-                    List<String> imageUrls = articleImageRepository.findImageUrlsByArticleId(articleId);
+        return getArticleResponses(articles);
+    }
 
-                    return ArticleResponse.builder()
-                            .id(articleId)
-                            .content(tuple.get("articleContent", String.class))
-                            .createdAt(tuple.get("articleCreatedAt", LocalDateTime.class))
-                            .imageUrls(imageUrls)
-                            .likes(tuple.get("likes", Long.class))
-                            .memberId(tuple.get("memberId", Long.class))
-                            .memberNickname(tuple.get("memberNickname", String.class))
-                            .build();
-                })
-                .toList();
+    @Override
+    public List<ArticleResponse> getAtriclesOfAttraction(Integer attractionId, Long cursorId) {
+        List<Tuple> articles = articleRepository.findArticlesByAttraction(
+                attractionId, cursorId, Pagination.PAGE_SIZE.getValue()
+        );
+
+        return getArticleResponses(articles);
     }
 
     @Override
@@ -205,5 +200,24 @@ public class ArticleServiceImpl implements ArticleService {
             throw new BadRequestException(ErrorCode.IMAGE_READ_ERROR);
         }
         return convertFile;
+    }
+
+    private List<ArticleResponse> getArticleResponses(List<Tuple> articles) {
+        return articles.stream()
+                .map(tuple -> {
+                    Long articleId = tuple.get("articleId", Long.class);
+                    List<String> imageUrls = articleImageRepository.findImageUrlsByArticleId(articleId);
+
+                    return ArticleResponse.builder()
+                            .id(articleId)
+                            .content(tuple.get("articleContent", String.class))
+                            .createdAt(tuple.get("articleCreatedAt", LocalDateTime.class))
+                            .imageUrls(imageUrls)
+                            .likes(tuple.get("likes", Long.class))
+                            .memberId(tuple.get("memberId", Long.class))
+                            .memberNickname(tuple.get("memberNickname", String.class))
+                            .build();
+                })
+                .toList();
     }
 }


### PR DESCRIPTION
### ✏️ 완료한 기능 명세

- [x] 관광지 관련 게시물 조회 API 구현


### 📷 결과물 이미지

![image](https://github.com/user-attachments/assets/c4a4bd1d-8343-43d3-89c3-d83afd761e5e)


### 🤔 고민한 부분

- service로직에서 `ArticleResponse` 리스트를 만드는 과정이 다른 메서드와 중복이 되어 private method로 분리했습니다.
