### PR TITLE
Feat: 회원정보 수정 기능 추가

### DIFF
--- a/src/main/java/com/ssafy/trip/common/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/trip/common/exception/ErrorCode.java
@@ -19,7 +19,9 @@ public enum ErrorCode {
     MEMBER_NOT_MATCH(HttpStatus.BAD_REQUEST, "Request member does not match the session info"),
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Member is not found"),
-    ATTRACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Attraction is not found");
+    ATTRACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Attraction is not found"),
+
+    NICKNAME_ALREADY_EXIST(HttpStatus.CONFLICT, "Nickname already exist"),;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ssafy/trip/common/exception/custom/ConflictException.java
+++ b/src/main/java/com/ssafy/trip/common/exception/custom/ConflictException.java
@@ -1,0 +1,16 @@
+package com.ssafy.trip.common.exception.custom;
+
+import com.ssafy.trip.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ConflictException extends RuntimeException {
+    private final HttpStatus status;
+    private final String message;
+
+    public ConflictException(ErrorCode errorCode) {
+        this.status = errorCode.getStatus();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/ssafy/trip/common/exception/custom/NicknameConflictException.java
+++ b/src/main/java/com/ssafy/trip/common/exception/custom/NicknameConflictException.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class ConflictException extends RuntimeException {
+public class NicknameConflictException extends RuntimeException {
     private final HttpStatus status;
     private final String message;
 
-    public ConflictException(ErrorCode errorCode) {
+    public NicknameConflictException(ErrorCode errorCode) {
         this.status = errorCode.getStatus();
         this.message = errorCode.getMessage();
     }

--- a/src/main/java/com/ssafy/trip/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/trip/member/controller/MemberController.java
@@ -19,8 +19,10 @@ import java.util.Map;
 public class MemberController {
     private final MemberService memberService;
 
-    @GetMapping("/{memberId}")
-    public ResponseEntity<MemberResponse> findById(@PathVariable("memberId") Long id) {
+    @GetMapping
+    public ResponseEntity<MemberResponse> findById(HttpSession httpSession) {
+        Map<String, Object> userInfo = (HashMap<String, Object>) httpSession.getAttribute("userInfo");
+        Long id = (Long) userInfo.get("id");
         Member member = memberService.findById(id);
         MemberResponse memberResponse = MemberResponse.builder()
                 .id(member.getId())
@@ -32,7 +34,7 @@ public class MemberController {
     }
 
     @PatchMapping
-    public ResponseEntity<MemberResponse> modifyMember(
+    public ResponseEntity<Void> modifyMember(
             @RequestPart(required = false) MultipartFile imageFile,
             @RequestPart(required = false) String nickname,
             HttpSession httpSession) {
@@ -40,6 +42,6 @@ public class MemberController {
         Long id = (Long) userInfo.get("id");
         memberService.modifyMember(id, imageFile, nickname);
 
-        return ResponseEntity.status(HttpStatus.OK).body(this.findById(id).getBody());
+        return ResponseEntity.status(HttpStatus.OK).body(null);
     }
 }

--- a/src/main/java/com/ssafy/trip/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/trip/member/controller/MemberController.java
@@ -2,24 +2,26 @@ package com.ssafy.trip.member.controller;
 
 import com.ssafy.trip.member.domain.Member;
 import com.ssafy.trip.member.dto.MemberResponse;
-import com.ssafy.trip.member.service.MemberService;
+import com.ssafy.trip.member.service.MemberServiceImpl;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberController {
-    private final MemberService memberService;
+    private final MemberServiceImpl memberServiceImpl;
 
     @GetMapping("/{memberId}")
     public ResponseEntity<MemberResponse> findById(@PathVariable("memberId") Long id) {
-        Member member = memberService.findById(id);
+        Member member = memberServiceImpl.findById(id);
         MemberResponse memberResponse = MemberResponse.builder()
                 .id(member.getId())
                 .nickname(member.getNickname())
@@ -27,5 +29,17 @@ public class MemberController {
                 .build();
 
         return ResponseEntity.status(HttpStatus.OK).body(memberResponse);
+    }
+
+    @PatchMapping
+    public ResponseEntity<?> modifyMember(
+            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
+            @RequestPart(value = "nickname", required = false) String nickname,
+            HttpSession httpSession) {
+        Map<String, Object> userInfo = (HashMap<String, Object>) httpSession.getAttribute("userInfo");
+        Long id = (Long) userInfo.get("id");
+        memberServiceImpl.modifyMember(id, imageFile, nickname);
+
+        return ResponseEntity.status(HttpStatus.OK).body(null);
     }
 }

--- a/src/main/java/com/ssafy/trip/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/trip/member/controller/MemberController.java
@@ -2,7 +2,7 @@ package com.ssafy.trip.member.controller;
 
 import com.ssafy.trip.member.domain.Member;
 import com.ssafy.trip.member.dto.MemberResponse;
-import com.ssafy.trip.member.service.MemberServiceImpl;
+import com.ssafy.trip.member.service.MemberService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,11 +17,11 @@ import java.util.Map;
 @RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberController {
-    private final MemberServiceImpl memberServiceImpl;
+    private final MemberService memberService;
 
     @GetMapping("/{memberId}")
     public ResponseEntity<MemberResponse> findById(@PathVariable("memberId") Long id) {
-        Member member = memberServiceImpl.findById(id);
+        Member member = memberService.findById(id);
         MemberResponse memberResponse = MemberResponse.builder()
                 .id(member.getId())
                 .nickname(member.getNickname())
@@ -38,7 +38,7 @@ public class MemberController {
             HttpSession httpSession) {
         Map<String, Object> userInfo = (HashMap<String, Object>) httpSession.getAttribute("userInfo");
         Long id = (Long) userInfo.get("id");
-        memberServiceImpl.modifyMember(id, imageFile, nickname);
+        memberService.modifyMember(id, imageFile, nickname);
 
         return ResponseEntity.status(HttpStatus.OK).body(null);
     }

--- a/src/main/java/com/ssafy/trip/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/trip/member/controller/MemberController.java
@@ -32,14 +32,14 @@ public class MemberController {
     }
 
     @PatchMapping
-    public ResponseEntity<?> modifyMember(
-            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
-            @RequestPart(value = "nickname", required = false) String nickname,
+    public ResponseEntity<MemberResponse> modifyMember(
+            @RequestPart(required = false) MultipartFile imageFile,
+            @RequestPart(required = false) String nickname,
             HttpSession httpSession) {
         Map<String, Object> userInfo = (HashMap<String, Object>) httpSession.getAttribute("userInfo");
         Long id = (Long) userInfo.get("id");
         memberService.modifyMember(id, imageFile, nickname);
 
-        return ResponseEntity.status(HttpStatus.OK).body(null);
+        return ResponseEntity.status(HttpStatus.OK).body(this.findById(id).getBody());
     }
 }

--- a/src/main/java/com/ssafy/trip/member/domain/Member.java
+++ b/src/main/java/com/ssafy/trip/member/domain/Member.java
@@ -33,8 +33,7 @@ public class Member extends BaseTimeEntity {
     private LocalDateTime deletedAt;
 
     @Builder
-    public Member(Long id, String nickname, String profileUrl, String socialId, String socialType) {
-        this.id = id;
+    public Member(String nickname, String profileUrl, String socialId, String socialType) {
         this.nickname = nickname;
         this.profileUrl = profileUrl;
         this.socialId = socialId;

--- a/src/main/java/com/ssafy/trip/member/domain/Member.java
+++ b/src/main/java/com/ssafy/trip/member/domain/Member.java
@@ -33,13 +33,12 @@ public class Member extends BaseTimeEntity {
     private LocalDateTime deletedAt;
 
     @Builder
-    public Member(Long id, String nickname, String profileUrl, String socialId, String socialType, LocalDateTime deletedAt) {
+    public Member(Long id, String nickname, String profileUrl, String socialId, String socialType) {
         this.id = id;
         this.nickname = nickname;
         this.profileUrl = profileUrl;
         this.socialId = socialId;
         this.socialType = socialType;
-        this.deletedAt = deletedAt;
     }
 
     public void updateProfileUrl(String profileUrl) {

--- a/src/main/java/com/ssafy/trip/member/domain/Member.java
+++ b/src/main/java/com/ssafy/trip/member/domain/Member.java
@@ -4,13 +4,11 @@ import com.ssafy.trip.common.jpa.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "members")
 public class Member extends BaseTimeEntity {
@@ -35,11 +33,21 @@ public class Member extends BaseTimeEntity {
     private LocalDateTime deletedAt;
 
     @Builder
-    public Member(String nickname, String profileUrl, String socialId, String socialType, LocalDateTime deletedAt) {
+    public Member(Long id, String nickname, String profileUrl, String socialId, String socialType, LocalDateTime deletedAt) {
+        this.id = id;
         this.nickname = nickname;
         this.profileUrl = profileUrl;
         this.socialId = socialId;
         this.socialType = socialType;
         this.deletedAt = deletedAt;
     }
+
+    public void updateProfileUrl(String profileUrl) {
+        this.profileUrl = profileUrl;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
 }

--- a/src/main/java/com/ssafy/trip/member/repository/MemberRepository.java
+++ b/src/main/java/com/ssafy/trip/member/repository/MemberRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsBySocialId(String socialId);
+    boolean existsByNickname(String nickname);
     Member findBySocialId(String socialId);
     Optional<Member> findByIdAndDeletedAtIsNull(long id);
 }

--- a/src/main/java/com/ssafy/trip/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/trip/member/service/MemberService.java
@@ -1,22 +1,9 @@
 package com.ssafy.trip.member.service;
 
-import com.ssafy.trip.common.exception.ErrorCode;
-import com.ssafy.trip.common.exception.custom.NotFoundException;
 import com.ssafy.trip.member.domain.Member;
-import com.ssafy.trip.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
-@Service
-@RequiredArgsConstructor
-public class MemberService {
-    private final MemberRepository memberRepository;
-
-    @Transactional(readOnly = true)
-    public Member findById(Long id) {
-        return memberRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(() ->
-                new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
-    }
-
+public interface MemberService {
+    Member findById(Long id);
+    void modifyMember(Long memberId, MultipartFile imageFile, String nickname);
 }

--- a/src/main/java/com/ssafy/trip/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/member/service/MemberServiceImpl.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.ssafy.trip.common.exception.ErrorCode;
 import com.ssafy.trip.common.exception.custom.BadRequestException;
+import com.ssafy.trip.common.exception.custom.ConflictException;
 import com.ssafy.trip.common.exception.custom.NotFoundException;
 import com.ssafy.trip.member.domain.Member;
 import com.ssafy.trip.member.repository.MemberRepository;
@@ -41,6 +42,9 @@ public class MemberServiceImpl implements MemberService {
                 new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
         if (nickname != null) {
+            if (!member.getNickname().equals(nickname) && memberRepository.existsByNickname(nickname)) {
+                throw new ConflictException(ErrorCode.NICKNAME_ALREADY_EXIST);
+            }
             member.updateNickname(nickname);
         }
 

--- a/src/main/java/com/ssafy/trip/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/member/service/MemberServiceImpl.java
@@ -5,7 +5,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.ssafy.trip.common.exception.ErrorCode;
 import com.ssafy.trip.common.exception.custom.BadRequestException;
-import com.ssafy.trip.common.exception.custom.ConflictException;
+import com.ssafy.trip.common.exception.custom.NicknameConflictException;
 import com.ssafy.trip.common.exception.custom.NotFoundException;
 import com.ssafy.trip.member.domain.Member;
 import com.ssafy.trip.member.repository.MemberRepository;
@@ -43,13 +43,13 @@ public class MemberServiceImpl implements MemberService {
 
         if (nickname != null && !member.getNickname().equals(nickname)) {
             if (memberRepository.existsByNickname(nickname)) {
-                throw new ConflictException(ErrorCode.NICKNAME_ALREADY_EXIST);
+                throw new NicknameConflictException(ErrorCode.NICKNAME_ALREADY_EXIST);
             }
             member.updateNickname(nickname);
         }
 
-        nickname = member.getNickname();
         if (imageFile != null) {
+            nickname = member.getNickname();
             member.updateProfileUrl(uploadImage(nickname, imageFile));
         }
     }

--- a/src/main/java/com/ssafy/trip/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/member/service/MemberServiceImpl.java
@@ -1,0 +1,89 @@
+package com.ssafy.trip.member.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.ssafy.trip.common.exception.ErrorCode;
+import com.ssafy.trip.common.exception.custom.BadRequestException;
+import com.ssafy.trip.common.exception.custom.NotFoundException;
+import com.ssafy.trip.member.domain.Member;
+import com.ssafy.trip.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberServiceImpl implements MemberService {
+    private final MemberRepository memberRepository;
+    private final AmazonS3 s3Client;
+
+    @Value("${aws-adk.bucketName}")
+    private String bucketName;
+
+    @Transactional(readOnly = true)
+    public Member findById(Long id) {
+        return memberRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(() ->
+                new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    @Override
+    public void modifyMember(Long id, MultipartFile imageFile, String nickname) {
+        Member member = memberRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(() ->
+                new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (nickname != null) {
+            member.updateNickname(nickname);
+        }
+
+        nickname = member.getNickname();
+        if (imageFile != null) {
+            member.updateProfileUrl(uploadImage(nickname, imageFile));
+        }
+    }
+
+    private String uploadImage(String nickname, MultipartFile imageFile) {
+        File uploadedFile = convert(imageFile);
+        return uploadImage(nickname, uploadedFile);
+    }
+
+    private String uploadImage(String nickname, File imageFile) {
+        String fileName = nickname + "/" + imageFile.getName();
+
+        s3Client.putObject(
+                new PutObjectRequest(bucketName, fileName, imageFile)
+                        .withCannedAcl(CannedAccessControlList.PublicRead));
+
+        imageFile.delete();
+
+        return s3Client.getUrl(bucketName, fileName).toString();
+    }
+
+    private File convert(MultipartFile imageFile) {
+        String filename = UUID.randomUUID().toString().substring(0, 10)
+                + "_" + imageFile.getOriginalFilename();
+        File convertFile = new File(filename);
+
+        try {
+            if (!convertFile.exists()) {
+                convertFile.createNewFile();
+            }
+
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                fos.write(imageFile.getBytes());
+            }
+        } catch (IOException e) {
+            throw new BadRequestException(ErrorCode.IMAGE_READ_ERROR);
+        }
+        return convertFile;
+    }
+
+}

--- a/src/main/java/com/ssafy/trip/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/member/service/MemberServiceImpl.java
@@ -41,8 +41,8 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(() ->
                 new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
-        if (nickname != null) {
-            if (!member.getNickname().equals(nickname) && memberRepository.existsByNickname(nickname)) {
+        if (nickname != null && !member.getNickname().equals(nickname)) {
+            if (memberRepository.existsByNickname(nickname)) {
                 throw new ConflictException(ErrorCode.NICKNAME_ALREADY_EXIST);
             }
             member.updateNickname(nickname);


### PR DESCRIPTION
### ✏️ 완료한 기능 명세

- [x] 회원정보 수정 기능 (닉네임, 프로필사진)
- [x] 닉네임 중복 시 예외처리

### 📷 결과물 이미지

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/c8a44f72-891f-4efc-a9b4-9427500081c4">

<img width="509" alt="image" src="https://github.com/user-attachments/assets/9f378222-7b02-4225-8022-3b0cde6086b0">

### 🤔 고민한 부분

- 여러 개의 데이터를 수정할 경우를 고려하기 위해 서비스 로직을 어떻게 구현할지 고민해봤습니다. 
- 닉네임이 중복될 경우와 닉네임이 바뀌지 않을 경우를 고려했습니다. 
- 이미지 파일을 업로드 하는 부분은 게시글 이미지를 업로드하는 서비스로직에서 가져왔습니다. 추후 refactor 과정에서 util로 빼놓으면 좋을 것 같습니다...
