### PR TITLE
Feat: 관광지 검색에 필터 기능 추가

### DIFF
--- a/src/main/java/com/ssafy/trip/attraction/controller/AttractionController.java
+++ b/src/main/java/com/ssafy/trip/attraction/controller/AttractionController.java
@@ -31,10 +31,10 @@ public class AttractionController {
 
         List<AttractionSearchResponse> attractionDtoList = attractions.stream()
                 .map(attraction -> AttractionSearchResponse.builder()
-                        .attraction_id(attraction.getNo())
+                        .attractionId(attraction.getNo())
                         .title(attraction.getTitle())
-                        .first_image1(attraction.getFirstImage1())
-                        .first_image2(attraction.getFirstImage2())
+                        .firstImage1(attraction.getFirstImage1())
+                        .firstImage2(attraction.getFirstImage2())
                         .latitude(attraction.getLatitude())
                         .longitude((attraction.getLongitude()))
                         .address(attraction.getAddr1())
@@ -44,7 +44,7 @@ public class AttractionController {
 
         AttractionSearchPagingResponse responseDto = AttractionSearchPagingResponse.builder()
                 .attractions(attractionDtoList)
-                .lastId(attractionDtoList.get(attractionDtoList.size()-1).getAttraction_id())
+                .lastId(attractionDtoList.get(attractionDtoList.size()-1).getAttractionId())
                 .build();
 
         return ResponseEntity.ok(responseDto);

--- a/src/main/java/com/ssafy/trip/attraction/controller/AttractionController.java
+++ b/src/main/java/com/ssafy/trip/attraction/controller/AttractionController.java
@@ -24,10 +24,19 @@ public class AttractionController {
 
     @GetMapping("/search")
     public ResponseEntity<AttractionSearchPagingResponse> findAttractionsByKeyword(
-            @RequestParam @NotBlank String keyword,
-            @RequestParam(defaultValue = DEFAULT_CURSOR_ID) Integer cursorId
+            @ModelAttribute AttractionSearchRequest searchRequest
     ) {
-        List<Attraction> attractions = attractionService.findAttractionsByKeyword(keyword, cursorId);
+        List<Attraction> attractions = attractionService.findAttractionsByKeyword(
+                searchRequest.getKeyword(),
+                searchRequest.getCursorId(),
+                searchRequest.getSpot(),
+                searchRequest.getFacility(),
+                searchRequest.getFestival(),
+                searchRequest.getLeports(),
+                searchRequest.getStay(),
+                searchRequest.getShopping(),
+                searchRequest.getRestaurant()
+        );
 
         List<AttractionSearchResponse> attractionDtoList = attractions.stream()
                 .map(attraction -> AttractionSearchResponse.builder()

--- a/src/main/java/com/ssafy/trip/attraction/dto/AttractionSearchRequest.java
+++ b/src/main/java/com/ssafy/trip/attraction/dto/AttractionSearchRequest.java
@@ -1,0 +1,41 @@
+package com.ssafy.trip.attraction.dto;
+
+import com.drew.lang.annotations.NotNull;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class AttractionSearchRequest {
+    private static final Integer DEFAULT_CURSOR_ID = 0;
+
+    @NotNull
+    private String keyword;
+
+    private Integer cursorId;
+
+    @NotNull
+    private Boolean spot;
+
+    @NotNull
+    private Boolean facility;
+
+    @NotNull
+    private Boolean festival;
+
+    @NotNull
+    private Boolean leports;
+
+    @NotNull
+    private Boolean stay;
+
+    @NotNull
+    private Boolean shopping;
+
+    @NotNull
+    private Boolean restaurant;
+
+    public Integer getCursorId() {
+        return cursorId != null ? cursorId : DEFAULT_CURSOR_ID;
+    }
+}

--- a/src/main/java/com/ssafy/trip/attraction/dto/AttractionSearchRequest.java
+++ b/src/main/java/com/ssafy/trip/attraction/dto/AttractionSearchRequest.java
@@ -1,6 +1,6 @@
 package com.ssafy.trip.attraction.dto;
 
-import com.drew.lang.annotations.NotNull;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;

--- a/src/main/java/com/ssafy/trip/attraction/dto/AttractionSearchRequest.java
+++ b/src/main/java/com/ssafy/trip/attraction/dto/AttractionSearchRequest.java
@@ -1,11 +1,13 @@
 package com.ssafy.trip.attraction.dto;
 
 import com.drew.lang.annotations.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
 @ToString
 @Getter
+@Builder
 public class AttractionSearchRequest {
     private static final Integer DEFAULT_CURSOR_ID = 0;
 

--- a/src/main/java/com/ssafy/trip/attraction/dto/AttractionSearchResponse.java
+++ b/src/main/java/com/ssafy/trip/attraction/dto/AttractionSearchResponse.java
@@ -10,10 +10,10 @@ import java.math.BigDecimal;
 @Getter
 @Builder
 public class AttractionSearchResponse {
-    private Integer attraction_id;
+    private Integer attractionId;
     private String title;
-    private String first_image1;
-    private String first_image2;
+    private String firstImage1;
+    private String firstImage2;
     private BigDecimal latitude;
     private BigDecimal longitude;
     private String address;

--- a/src/main/java/com/ssafy/trip/attraction/repository/AttractionMapper.java
+++ b/src/main/java/com/ssafy/trip/attraction/repository/AttractionMapper.java
@@ -9,6 +9,10 @@ import java.util.List;
 
 @Mapper
 public interface AttractionMapper {
-    List<Attraction> selectAttractionsByKeyword(String keyword, int cursorId);
+    List<Attraction> selectAttractionsByKeyword(
+            String keyword,
+            Integer cursorId,
+            List<Integer> contentTypes
+    );
     List<AttractionNearByResponse> selectAttractionsByDistance(BigDecimal lat, BigDecimal lng, int cursorId);
 }

--- a/src/main/java/com/ssafy/trip/attraction/service/AttractionService.java
+++ b/src/main/java/com/ssafy/trip/attraction/service/AttractionService.java
@@ -1,5 +1,6 @@
 package com.ssafy.trip.attraction.service;
 
+import com.drew.lang.annotations.NotNull;
 import com.ssafy.trip.attraction.domain.Attraction;
 import com.ssafy.trip.attraction.dto.AttractionNearByResponse;
 
@@ -7,6 +8,16 @@ import java.math.BigDecimal;
 import java.util.List;
 
 public interface AttractionService {
-    List<Attraction> findAttractionsByKeyword(String keyword, int cursorId);
+    List<Attraction> findAttractionsByKeyword(
+            String keyword,
+            Integer cursorId,
+            Boolean spot,
+            Boolean facility,
+            Boolean festival,
+            Boolean leports,
+            Boolean stay,
+            Boolean shopping,
+            Boolean restaurant
+    );
     List<AttractionNearByResponse> findAttractionsByDistance(BigDecimal latitude, BigDecimal longitude, int cursorId);
 }

--- a/src/main/java/com/ssafy/trip/attraction/service/AttractionService.java
+++ b/src/main/java/com/ssafy/trip/attraction/service/AttractionService.java
@@ -1,6 +1,5 @@
 package com.ssafy.trip.attraction.service;
 
-import com.drew.lang.annotations.NotNull;
 import com.ssafy.trip.attraction.domain.Attraction;
 import com.ssafy.trip.attraction.dto.AttractionNearByResponse;
 
@@ -19,5 +18,6 @@ public interface AttractionService {
             Boolean shopping,
             Boolean restaurant
     );
+
     List<AttractionNearByResponse> findAttractionsByDistance(BigDecimal latitude, BigDecimal longitude, int cursorId);
 }

--- a/src/main/java/com/ssafy/trip/attraction/service/AttractionServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/attraction/service/AttractionServiceImpl.java
@@ -4,8 +4,6 @@ import com.ssafy.trip.attraction.domain.Attraction;
 import com.ssafy.trip.attraction.dto.AttractionNearByResponse;
 import com.ssafy.trip.attraction.repository.AttractionMapper;
 import com.ssafy.trip.attraction.util.ContentType;
-import com.ssafy.trip.common.exception.ErrorCode;
-import com.ssafy.trip.common.exception.custom.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/ssafy/trip/attraction/service/AttractionServiceImpl.java
+++ b/src/main/java/com/ssafy/trip/attraction/service/AttractionServiceImpl.java
@@ -3,6 +3,7 @@ package com.ssafy.trip.attraction.service;
 import com.ssafy.trip.attraction.domain.Attraction;
 import com.ssafy.trip.attraction.dto.AttractionNearByResponse;
 import com.ssafy.trip.attraction.repository.AttractionMapper;
+import com.ssafy.trip.attraction.util.ContentType;
 import com.ssafy.trip.common.exception.ErrorCode;
 import com.ssafy.trip.common.exception.custom.BadRequestException;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -19,8 +21,41 @@ public class AttractionServiceImpl implements AttractionService {
     private final AttractionMapper attractionMapper;
 
     @Override
-    public List<Attraction> findAttractionsByKeyword(String keyword, int cursorId) {
-        return attractionMapper.selectAttractionsByKeyword(keyword, cursorId);
+    public List<Attraction> findAttractionsByKeyword(
+            String keyword,
+            Integer cursorId,
+            Boolean spot,
+            Boolean facility,
+            Boolean festival,
+            Boolean leports,
+            Boolean stay,
+            Boolean shopping,
+            Boolean restaurant) {
+        List<Integer> contentTypes = new ArrayList<>();
+
+        if (spot) {
+            contentTypes.add(ContentType.SPOT.getContentTypeId());
+        }
+        if (facility) {
+            contentTypes.add(ContentType.FACILITY.getContentTypeId());
+        }
+        if (festival) {
+            contentTypes.add(ContentType.FESTIVAL.getContentTypeId());
+        }
+        if (leports) {
+            contentTypes.add(ContentType.LEPORTS.getContentTypeId());
+        }
+        if (stay) {
+            contentTypes.add(ContentType.STAY.getContentTypeId());
+        }
+        if (shopping) {
+            contentTypes.add(ContentType.SHOPPING.getContentTypeId());
+        }
+        if (restaurant) {
+            contentTypes.add(ContentType.RESTAURANT.getContentTypeId());
+        }
+
+        return attractionMapper.selectAttractionsByKeyword(keyword, cursorId, contentTypes);
     }
 
     @Override

--- a/src/main/java/com/ssafy/trip/attraction/util/ContentType.java
+++ b/src/main/java/com/ssafy/trip/attraction/util/ContentType.java
@@ -1,0 +1,18 @@
+package com.ssafy.trip.attraction.util;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ContentType {
+    SPOT(12),
+    FACILITY(14),
+    FESTIVAL(15),
+    LEPORTS(28),
+    STAY(32),
+    SHOPPING(38),
+    RESTAURANT(39);
+
+    private final Integer contentTypeId;
+}

--- a/src/main/resources/mappers/AttractionMapper.xml
+++ b/src/main/resources/mappers/AttractionMapper.xml
@@ -8,6 +8,12 @@
         from attractions
         where (title like concat('%',#{keyword},'%')
             or addr1 like concat('%',#{keyword},'%'))
+            and (
+                content_type_id in
+                <foreach item="item" collection="contentTypes" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+                )
             and no > #{cursorId}
         limit 5
     </select>


### PR DESCRIPTION
### ✏️ 완료한 기능 명세

- [x] 필터 기능 추가
- [x] content type Enum 생성


### 📷 결과물 이미지

![image](https://github.com/user-attachments/assets/696615eb-5df9-4a6e-843b-c337895d430f)


### 🤔 고민한 부분

- 프론트에서 각각의 content type에 대해 쿼리 스트링으로 모두 체크 여부를 넘겨주고 이를 백엔드에서 받아서 리스트에 담아 MyBatis로 조회합니다. 프론트에서 보낼 때 정보를 쿼리 스트링에 "content-type=1,2,3,4" 이렇게 보내려고 했지만 검증 과정이 복잡해질 것 같아 현재 방식을 적용했습니다.